### PR TITLE
Add PDFViewer specific variables

### DIFF
--- a/external/types/pdf.d.ts
+++ b/external/types/pdf.d.ts
@@ -78,6 +78,8 @@ declare module 'pdfjs-dist' {
 
   //
   // web/pdf_viewer.component.js
+  // Warning: These functions are only accessible with web/pdf_viewer.js.
+  //          It is NOT automatically imported with 'pdfjs-dist'.
   //
   export namespace PDFJS {
     export import PDFViewer = _pdfjs.PDFViewer;
@@ -96,6 +98,21 @@ declare module 'pdfjs-dist' {
     export import ProgressBar = _pdfjs.ProgressBar;
     export import GenericL10n = _pdfjs.GenericL10n;
     export import NullL10n = _pdfjs.NullL10n;
+    export import showPreviousViewOnLoad = _pdfjs.showPreviousViewOnLoad;
+    export import defaultZoomValue = _pdfjs.defaultZoomValue;
+    export import sidebarViewOnLoad = _pdfjs.sidebarViewOnLoad;
+    export import enableHandToolOnLoad = _pdfjs.enableHandToolOnLoad;
+    export import cursorToolOnLoad = _pdfjs.cursorToolOnLoad;
+    export import enableWebGL = _pdfjs.enableWebGL;
+    export import pdfBugEnabled = _pdfjs.pdfBugEnabled;
+    export import disableTextLayer = _pdfjs.disableTextLayer;
+    export import useOnlyCssZoom = _pdfjs.useOnlyCssZoom;
+    export import enhanceTextSelection = _pdfjs.enhanceTextSelection;
+    export import renderer = _pdfjs.renderer;
+    export import renderInteractiveForms = _pdfjs.renderInteractiveForms;
+    export import enablePrintAutoRotate = _pdfjs.enablePrintAutoRotate;
+    export import disablePageMode = _pdfjs.disablePageMode;
+    export import disablePageLabels = _pdfjs.disablePageLabels;
   }
 
   //

--- a/external/types/web.d.ts
+++ b/external/types/web.d.ts
@@ -530,7 +530,7 @@ declare namespace _pdfjs {
   //
   // web/pdf_find_controller.js
   //
-  
+
   interface PDFFindControllerOptions { pdfViewer: PDFViewer, }
 
   interface FindCommandState {
@@ -921,4 +921,120 @@ declare namespace _pdfjs {
 
   // Constructor function
   let GenericL10n: new (lang: string) => GenericL10n;
+
+  //
+  // web/app.js
+  //
+  /**
+   * Shows the previous view position on loading the PDF
+   * @var {boolean}
+   * default: true
+   */
+  let showPreviousViewOnLoad: boolean;
+
+  /**
+   * Sets a default zoom value
+   * @var {string}
+   * default: ""
+   */
+  let defaultZoomValue: string;
+
+  /**
+   * The sidebar view on load
+   * @var {number}
+   * default: 0
+   */
+  let sidebarViewOnLoad: number;
+
+  /**
+   * Enables WebGL usage
+   * @var {boolean}
+   * default: false
+   */
+  let enableWebGL: boolean;
+
+  /**
+   * Enables the PDF debugging tool
+   * @var {boolean}
+   * default: false
+   */
+  let pdfBugEnabled: boolean;
+
+  /**
+   * Disables the Text Layer
+   * @var {boolean}
+   * default: false
+   */
+  let disableTextLayer: boolean;
+
+  /**
+   * Allows only the use of CSS Zoom
+   * @var {boolean}
+   * default: false
+   */
+  let useOnlyCssZoom: boolean;
+
+  /**
+   * Disables Page Mode
+   * @var {boolean}
+   * default: false
+   */
+  let disablePageMode: boolean;
+
+  /**
+   * Disables the Page Labels
+   * @var {boolean}
+   * default: false
+   */
+  let disablePageLabels: boolean;
+
+  //
+  // web/chromecom.js
+  //
+  /**
+   * Enables the Hand Tool on load
+   * @var {boolean}
+   * default: false
+   */
+  let enableHandToolOnLoad: boolean;
+
+  /**
+   * Enables the Cursor Tool on load
+   * @var {number}
+   * default: 0
+   */
+  let cursorToolOnLoad: number;
+
+  //
+  // web/base_viewer.js
+  //
+  /**
+   * Enhances the Text Selection in the Text Layer
+   * (Works only if disableTextLayer is true)
+   * @var {boolean}
+   * default: false
+   */
+  let enhanceTextSelection: boolean;
+
+  /**
+   * Allows to define a renderer
+   * @var {string}
+   * default: canvas
+   */
+  let renderer: string;
+
+  /**
+   * Activate rendering of interactive forms
+   * @var {boolean}
+   * default: false
+   */
+  let renderInteractiveForms: boolean;
+
+  /**
+   * Enables autorotating when printing
+   * @var {boolean}
+   * default: false
+   */
+  let enablePrintAutoRotate: boolean;
+
 }


### PR DESCRIPTION
I added the `PDF_Viewer` or `web/` specific definitions to `web.d.ts` and referenced them in `pdf.d.ts`.

Some of the descriptions might be not entirely exact. Someone that has used these functions and knows what they do exactly might need to update the descriptions.

Trying to solve: https://github.com/acchou/pdf.js/issues/1